### PR TITLE
Fixes 404 issues for composer support section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         "translate"
     ],
     "support": {
-        "docs": "https://github.com/boldenamsterdam/hello-translated/blob/master/README.md",
-        "issues": "https://github.com/boldenamsterdam/hello-translated/issues"
+        "docs": "https://github.com/boldenamsterdam/hellotranslated/blob/master/README.md",
+        "issues": "https://github.com/boldenamsterdam/hellotranslated/issues"
     },
     "license": "MIT",
     "authors": [{


### PR DESCRIPTION
Quick fix some your plugins documentation links correctly on https://plugins.craftcms.com/hello-translated.  